### PR TITLE
Fixing the error with GIT PUSH in "Generate markdown document & commit" task

### DIFF
--- a/intune-backup-pipeline.yml
+++ b/intune-backup-pipeline.yml
@@ -387,6 +387,9 @@ jobs:
       #         git config user.email $(USER_EMAIL)
       #         git add --all
       #         git commit -m "Intune config as-built $DATEF"
+      #         # 2024-02-27 Recommended by Copilot after reporting the error with GIT PUSH:
+      #         # "Updates were rejected because a pushed branch tip is behind its remote counterpart. If you want to integrate the remote changes, use 'git pull' before pushing again. See the 'Note about fast-forwards' in 'git push --help' for details."
+      #         git pull origin main
       #         git push origin HEAD:main
       #       else
       #         echo "no configuration backup change detected in the last commit, documentation will not be created"


### PR DESCRIPTION
Fixing the error with GIT PUSH: "Updates were rejected because a pushed branch tip is behind its remote counterpart. If you want to integrate the remote changes, use 'git pull' before pushing again. See the 'Note about fast-forwards' in 'git push --help' for details."
